### PR TITLE
Add codedeploy role

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ Adds a role and instance profile for KMS access.
     environment = "staging"
   }
 ```
+
+## codedeploy_role
+Add a role that can be attached to codedeploy deployment groups
+
+### Available variables
+/
+
+### Output
+* [`role_arn`]: String: The Amazon Resource Name (ARN) specifying the role.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ Add a role that can be attached to codedeploy deployment groups
 
 ### Output
 * [`role_arn`]: String: The Amazon Resource Name (ARN) specifying the role.
+
+### Example
+```
+  module "codedeploy_role" {
+    source      = "github.com/skyscrapers/terraform-iam//codedeploy_role"
+  }
+
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Add a role that can be attached to codedeploy deployment groups
 ```
   module "codedeploy_role" {
     source      = "github.com/skyscrapers/terraform-iam//codedeploy_role"
+    region      = "eu-west-1"
   }
 
 ```

--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role" "codedeploy_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "codedeploy.eu-west-1.amazonaws.com"
+        "Service": "codedeploy.${var.region}.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }

--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -1,0 +1,47 @@
+
+resource "aws_iam_role_policy" "codedeploy_policy" {
+    name = "codedeploy"
+    role = "${aws_iam_role.codedeploy_role.id}"
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DeleteLifecycleHook",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLifecycleHooks",
+                "autoscaling:PutLifecycleHook",
+                "autoscaling:RecordLifecycleActionHeartbeat",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "tag:GetTags",
+            "tag:GetResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "codedeploy_role" {
+    name = "codedeploy-role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codedeploy.eu-west-1.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}

--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -18,7 +18,7 @@ resource "aws_iam_role_policy" "codedeploy_policy" {
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
                 "tag:GetTags",
-            "tag:GetResources"
+                "tag:GetResources"
             ],
             "Resource": "*"
         }

--- a/codedeploy_role/outputs.tf
+++ b/codedeploy_role/outputs.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = "${aws_iam_role.codedeploy_role.arn}"
+}

--- a/codedeploy_role/variables.tf
+++ b/codedeploy_role/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  description = "Region where codedeploy will run in"
+  default = "eu-west-1"
+}


### PR DESCRIPTION
I created this IAM role so this can be used together with an codedeploy deployment group.

This can be used for all codedeploy applications in one AWS account.