### PR TITLE
adding cloudwatch monitoring role

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,25 @@ Add a role that can be used by cloudcheckr to collect data and stats
 
 
 ```
+
+
+## CloudWatch Monitoring role
+Adding role for cloudwatch monitoring to allow instance to send custom metrics
+
+### Available variables
+* [`instance_role`]: String: The name of the instance role to attach the policies to.
+* [`app`]: String: The name of the application to be used in role name.
+* [`project`]: String: The name of the project to be used in role name.
+* [`environment`]: String: The name of the enviroment to be used in role name.
+
+
+### Example
+```
+module "iam-monitoring" {
+  source        = "github.com/skyscrapers/terraform-iam//cloudwatch_monitoring_role"
+  environment   = "${terraform.workspace}"
+  project       = "${var.project}"
+  app           = "api"
+  instance_role = "${aws_iam_role.role.name}"
+}
+```

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ Add a role that can be used by cloudcheckr to collect data and stats
 Adding role for cloudwatch monitoring to allow instance to send custom metrics
 
 ### Available variables
-* [`instance_role`]: String: The name of the instance role to attach the policies to.
-* [`app`]: String: The name of the application to be used in role name.
-* [`project`]: String: The name of the project to be used in role name.
-* [`environment`]: String: The name of the enviroment to be used in role name.
+* [`instance_role`]: String(required): The name of the instance role to attach the policies to.
+* [`app`]: String(optional): The name of the application to be used in role name.
+* [`project`]: String(optional): The name of the project to be used in role name.
+* [`environment`]: String(optional): The name of the enviroment to be used in role name.
 
 
 ### Example

--- a/cloudwatch_monitoring_role/main.tf
+++ b/cloudwatch_monitoring_role/main.tf
@@ -1,0 +1,21 @@
+data "aws_iam_policy_document" "cloudwatch_monitoring_policy" {
+  statement {
+    sid     = "1"
+    actions = ["cloudwatch:PutMetricData", "cloudwatch:GetMetricStatistics", "cloudwatch:ListMetrics", "ec2:DescribeTags"]
+    effect  = "Allow"
+
+   resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cloudwatch_monitoring_policy" {
+  name   = "cloudwatch_${var.project}_${var.app}_${var.environment}"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.cloudwatch_monitoring_policy.json}"
+}
+
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_monitoring_access" {
+  role       = "${var.instance_role}"
+  policy_arn = "${aws_iam_policy.cloudwatch_monitoring_policy.arn}"
+}

--- a/cloudwatch_monitoring_role/main.tf
+++ b/cloudwatch_monitoring_role/main.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "cloudwatch_monitoring_policy" {
   statement {
-    sid     = "1"
+    sid     = "CloudWatchMonitoring"
     actions = ["cloudwatch:PutMetricData", "cloudwatch:GetMetricStatistics", "cloudwatch:ListMetrics", "ec2:DescribeTags"]
     effect  = "Allow"
 

--- a/cloudwatch_monitoring_role/variables.tf
+++ b/cloudwatch_monitoring_role/variables.tf
@@ -1,0 +1,11 @@
+variable "project" {
+}
+
+variable "environment" {
+}
+
+variable "instance_role" {
+}
+
+variable "app" {
+}

--- a/cloudwatch_monitoring_role/variables.tf
+++ b/cloudwatch_monitoring_role/variables.tf
@@ -1,11 +1,14 @@
 variable "project" {
+   default = ""
 }
 
 variable "environment" {
+  default = ""
 }
 
 variable "instance_role" {
 }
 
 variable "app" {
+   default = ""
 }


### PR DESCRIPTION
Adding role for cloudwatch monitoring to allow instance to send custom metrics, permissions are:
    cloudwatch:PutMetricData
    cloudwatch:GetMetricStatistics
    cloudwatch:ListMetrics
    ec2:DescribeTags