### PR TITLE
Add packer policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,18 @@ module "iam-monitoring" {
   instance_role = "${aws_iam_role.role.name}"
 }
 ```
+
+## packer_policy
+Creates an IAM policy that allows usage of a Packer with AWS EC2 EBS volumes.
+
+### Output
+* [`packer_policy_id`]: String: The generated policy id.
+* [`packer_policy_arn`]: String: The generated policy ARN.
+* [`packer_policy_name`]: String: The generated policy name.
+
+### Example
+```
+  module "packer_policy" {
+    source      = "github.com/skyscrapers/terraform-iam//packer_policy"
+  }
+```

--- a/packer_policy/main.tf
+++ b/packer_policy/main.tf
@@ -1,0 +1,49 @@
+resource "aws_iam_policy" "packer_policy" {
+  name        = "Packer policy"
+  path        = "/"
+  description = "Policy for Packer EC2 EBS"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+      "Effect": "Allow",
+      "Action" : [
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CopyImage",
+        "ec2:CreateImage",
+        "ec2:CreateKeypair",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteKeypair",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteSnapshot",
+        "ec2:DeleteVolume",
+        "ec2:DeregisterImage",
+        "ec2:DescribeImageAttribute",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DetachVolume",
+        "ec2:GetPasswordData",
+        "ec2:ModifyImageAttribute",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifySnapshotAttribute",
+        "ec2:RegisterImage",
+        "ec2:RunInstances",
+        "ec2:StopInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource" : "*"
+  }]
+}
+EOF
+}

--- a/packer_policy/outputs.tf
+++ b/packer_policy/outputs.tf
@@ -1,11 +1,14 @@
 output "packer_policy_arn" {
-  value = "${aws_iam_policy.packer_policy.arn}"
+  description = "The generated policy ARN"
+  value       = "${aws_iam_policy.packer_policy.arn}"
 }
 
 output "packer_policy_name" {
-  value = "${aws_iam_policy.packer_policy.name}"
+  description = "The generated policy name"
+  value       = "${aws_iam_policy.packer_policy.name}"
 }
 
 output "packer_policy_id" {
-  value = "${aws_iam_policy.packer_policy.id}"
+  description = "The generated policy id"
+  value       = "${aws_iam_policy.packer_policy.id}"
 }

--- a/packer_policy/outputs.tf
+++ b/packer_policy/outputs.tf
@@ -1,0 +1,11 @@
+output "packer_policy_arn" {
+  value = "${aws_iam_policy.packer_policy.arn}"
+}
+
+output "packer_policy_name" {
+  value = "${aws_iam_policy.packer_policy.name}"
+}
+
+output "packer_policy_id" {
+  value = "${aws_iam_policy.packer_policy.id}"
+}


### PR DESCRIPTION
We need a packer policy to allow us to create AMI images with packer. This allows the AWS EC2 EBS builder  at this moment.

Policy taken from https://www.packer.io/docs/builders/amazon.html#using-an-iam-task-or-instance-role