### PR TITLE
add PassRole for packer 

### DIFF
--- a/packer_policy/main.tf
+++ b/packer_policy/main.tf
@@ -9,6 +9,7 @@ resource "aws_iam_policy" "packer_policy" {
   "Statement": [{
       "Effect": "Allow",
       "Action" : [
+        "iam:PassRole",
         "ec2:AttachVolume",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CopyImage",


### PR DESCRIPTION
Getting `Error launching source instance: UnauthorizedOperation`,  PassRole is needed due to: 
https://github.com/hashicorp/packer/blob/master/website/source/docs/builders/amazon.html.md#attaching-iam-policies-to-roles
