### PR TITLE
moving to name-prefix to avoid conflict on codedeploy role name

### DIFF
--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -61,7 +61,7 @@ EOF
 }
 
 resource "aws_iam_role" "codedeploy_role" {
-    name = "codedeploy-role"
+    name_prefix = "codedeploy-role"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
This allows to have the role available in different regions for example without conflicts