### PR TITLE
Create base_roles module

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ Creates some base IAM roles:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin_account_id | Id of the AWS account of the admin account | string | - | yes |
-| admin_role_principals_arns | List of AWS principal ARNs that'll be allowed to assume the admin role in the ops account | list | - | yes |
+| admin_role_principal_ids | List of AWS principal ids (or ARNs) that'll be allowed to assume the admin role in the ops account | list | - | yes |
+| readonly_role_principal_ids | List of AWS principal ids (or ARNs) that'll be allowed to assume the readonly role in the ops account | list | - | yes |
 
 ### Outputs
 
@@ -270,8 +270,8 @@ Creates some base IAM roles:
 
 ```tf
 module "base_roles" {
-  source                     = "github.com/skyscrapers/terraform-iam//base_roles"
-  admin_account_id           = "109034686754"
-  admin_role_principals_arns = ["arn:aws:iam::109034686754:role/something"]
+  source                      = "github.com/skyscrapers/terraform-iam//base_roles"
+  readonly_role_principal_ids = ["109034686754"]
+  admin_role_principals_arns  = ["arn:aws:iam::109034686754:role/something"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -244,3 +244,34 @@ module "terraform_ci_user" {
   pgp_key = "keybase:some_person_that_exists"
 }
 ```
+
+## base_roles
+
+Creates some base IAM roles:
+
+* `admin` with `AdministratorAccess` policy attached
+* `ro` with `ReadOnlyAccess` policy attached
+
+### Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| admin_account_id | Id of the AWS account of the admin account | string | - | yes |
+| admin_role_principals_arns | List of AWS principal ARNs that'll be allowed to assume the admin role in the ops account | list | - | yes |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| admin_role_arn | Admin role ARN |
+| ro_role_arn | Readonly role ARN |
+
+### Example
+
+```tf
+module "base_roles" {
+  source                     = "github.com/skyscrapers/terraform-iam//base_roles"
+  admin_account_id           = "109034686754"
+  admin_role_principals_arns = ["arn:aws:iam::109034686754:role/something"]
+}
+```

--- a/base_roles/admin_role.tf
+++ b/base_roles/admin_role.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "admin_assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.admin_role_principals_arns}"]
+      identifiers = ["${var.admin_role_principal_ids}"]
     }
   }
 }

--- a/base_roles/admin_role.tf
+++ b/base_roles/admin_role.tf
@@ -1,0 +1,23 @@
+data "aws_iam_policy_document" "admin_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.admin_role_principals_arns}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "admin" {
+  name               = "admin"
+  path               = "/ops/"
+  description        = "This role has full Aministrator access and is to be assumed to mange this account"
+  assume_role_policy = "${data.aws_iam_policy_document.admin_assume_role_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "admin" {
+  role       = "${aws_iam_role.admin.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/base_roles/outputs.tf
+++ b/base_roles/outputs.tf
@@ -1,7 +1,9 @@
 output "admin_role_arn" {
-  value = "${aws_iam_role.admin.arn}"
+  value       = "${aws_iam_role.admin.arn}"
+  description = "Admin role ARN"
 }
 
 output "ro_role_arn" {
-  value = "${aws_iam_role.ro.arn}"
+  value       = "${aws_iam_role.ro.arn}"
+  description = "Readonly role ARN"
 }

--- a/base_roles/outputs.tf
+++ b/base_roles/outputs.tf
@@ -1,0 +1,7 @@
+output "admin_role_arn" {
+  value = "${aws_iam_role.admin.arn}"
+}
+
+output "ro_role_arn" {
+  value = "${aws_iam_role.ro.arn}"
+}

--- a/base_roles/ro_role.tf
+++ b/base_roles/ro_role.tf
@@ -19,5 +19,5 @@ resource "aws_iam_role" "ro" {
 
 resource "aws_iam_role_policy_attachment" "ro" {
   role       = "${aws_iam_role.ro.name}"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnly"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }

--- a/base_roles/ro_role.tf
+++ b/base_roles/ro_role.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "ro_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.admin_account_id}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ro" {
+  name               = "readonly"
+  description        = "This role has read only access to this account"
+  assume_role_policy = "${data.aws_iam_policy_document.ro_assume_role_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ro" {
+  role       = "${aws_iam_role.ro.name}"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnly"
+}

--- a/base_roles/ro_role.tf
+++ b/base_roles/ro_role.tf
@@ -12,6 +12,7 @@ data "aws_iam_policy_document" "ro_assume_role_policy" {
 
 resource "aws_iam_role" "ro" {
   name               = "readonly"
+  path               = "/ops/"
   description        = "This role has read only access to this account"
   assume_role_policy = "${data.aws_iam_policy_document.ro_assume_role_policy.json}"
 }

--- a/base_roles/ro_role.tf
+++ b/base_roles/ro_role.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "ro_assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.admin_account_id}"]
+      identifiers = ["${var.readonly_role_principal_ids}"]
     }
   }
 }

--- a/base_roles/variables.tf
+++ b/base_roles/variables.tf
@@ -1,0 +1,8 @@
+variable "admin_role_principals_arns" {
+  description = "List of AWS principal ARNs that'll be allowed to assume the admin role in the ops account"
+  type        = "list"
+}
+
+variable "admin_account_id" {
+  description = "Id of the AWS account of the admin account"
+}

--- a/base_roles/variables.tf
+++ b/base_roles/variables.tf
@@ -1,8 +1,9 @@
-variable "admin_role_principals_arns" {
-  description = "List of AWS principal ARNs that'll be allowed to assume the admin role in the ops account"
+variable "admin_role_principal_ids" {
+  description = "List of AWS principal ids (or ARNs) that'll be allowed to assume the admin role in the ops account"
   type        = "list"
 }
 
-variable "admin_account_id" {
-  description = "Id of the AWS account of the admin account"
+variable "readonly_role_principal_ids" {
+  description = "List of AWS principal ids (or ARNs) that'll be allowed to assume the readonly role in the ops account"
+  type        = "list"
 }


### PR DESCRIPTION
This module is meant to create some basic roles in a AWS account.

* `admin` with `AdministratorAccess` policy attached
* `ro` with `ReadOnlyAccess` policy attached

Principals for each role can be configured through variables.

As per https://github.com/skyscrapers/engineering/issues/147