### PR TITLE
updates CodeDeploy role with aws-managed policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,18 @@ EOF
 Add a role that can be attached to codedeploy deployment groups
 
 ### Available variables
-/
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| region | Region where codedeploy will run in | string | `"eu-west-1"` | no |
 
 ### Output
-* [`role_arn`]: String: The Amazon Resource Name (ARN) specifying the role.
-* [`role_name`]: String: The name of the role.
-* [`role_unique_id`]: String: The stable and unique string identifying the role.
+
+| Name | Description |
+|------|-------------|
+| role\_arn | The Amazon Resource Name (ARN) specifying the role. |
+| role\_name | The name of the role. |
+| role\_unique\_id | The stable and unique string identifying the role. |
 
 ### Example
 ```

--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -1,15 +1,12 @@
-
 resource "aws_iam_role_policy_attachment" "codedeploy_policy" {
-    role = "${aws_iam_role.codedeploy_role.id}"
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+  role       = "${aws_iam_role.codedeploy_role.id}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
 }
 
 resource "aws_iam_role" "codedeploy_role" {
-    name_prefix = "codedeploy-role"
-    assume_role_policy = "${data.aws_iam_policy_document.codedeploy_role.json}"
+  name_prefix        = "codedeploy-role"
+  assume_role_policy = "${data.aws_iam_policy_document.codedeploy_role.json}"
 }
-
-
 
 data "aws_iam_policy_document" "codedeploy_role" {
   statement {

--- a/codedeploy_role/main.tf
+++ b/codedeploy_role/main.tf
@@ -1,80 +1,24 @@
 
-resource "aws_iam_role_policy" "codedeploy_policy_sns" {
-    count = "${var.sns_notify ? 1 : 0}"
-    name = "codedeploy"
+resource "aws_iam_role_policy_attachment" "codedeploy_policy" {
     role = "${aws_iam_role.codedeploy_role.id}"
-    policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources",
-                "sns:Publish"
-
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "codedeploy_policy" {
-    count = "${var.sns_notify ? 0 : 1}"
-    name = "codedeploy"
-    role = "${aws_iam_role.codedeploy_role.id}"
-    policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources"
-
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
+    policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
 }
 
 resource "aws_iam_role" "codedeploy_role" {
     name_prefix = "codedeploy-role"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "codedeploy.${var.region}.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
+    assume_role_policy = "${data.aws_iam_policy_document.codedeploy_role.json}"
 }
-EOF
+
+
+
+data "aws_iam_policy_document" "codedeploy_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["codedeploy.${var.region}.amazonaws.com"]
+    }
+  }
 }

--- a/codedeploy_role/outputs.tf
+++ b/codedeploy_role/outputs.tf
@@ -1,14 +1,14 @@
 output "role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the role."
-  value = "${aws_iam_role.codedeploy_role.arn}"
+  value       = "${aws_iam_role.codedeploy_role.arn}"
 }
 
 output "role_name" {
   description = "The name of the role."
-  value = "${aws_iam_role.codedeploy_role.name}"
+  value       = "${aws_iam_role.codedeploy_role.name}"
 }
 
 output "role_unique_id" {
   description = "The stable and unique string identifying the role."
-  value = "${aws_iam_role.codedeploy_role.unique_id}"
+  value       = "${aws_iam_role.codedeploy_role.unique_id}"
 }

--- a/codedeploy_role/outputs.tf
+++ b/codedeploy_role/outputs.tf
@@ -1,11 +1,14 @@
 output "role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the role."
   value = "${aws_iam_role.codedeploy_role.arn}"
 }
 
 output "role_name" {
+  description = "The name of the role."
   value = "${aws_iam_role.codedeploy_role.name}"
 }
 
 output "role_unique_id" {
+  description = "The stable and unique string identifying the role."
   value = "${aws_iam_role.codedeploy_role.unique_id}"
 }

--- a/codedeploy_role/variables.tf
+++ b/codedeploy_role/variables.tf
@@ -2,6 +2,3 @@ variable "region" {
   description = "Region where codedeploy will run in"
   default = "eu-west-1"
 }
-variable "sns_notify" {
-  default = false
-}

--- a/codedeploy_role/variables.tf
+++ b/codedeploy_role/variables.tf
@@ -1,4 +1,4 @@
 variable "region" {
   description = "Region where codedeploy will run in"
-  default = "eu-west-1"
+  default     = "eu-west-1"
 }


### PR DESCRIPTION
This PR moves to the aws-managed CodeDeploy IAM policy.

It also refactors the documentation and the code to meet our standards