### PR TITLE
Fix user output

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Add a role that can be attached to codedeploy deployment groups
 * [`pgp_key`]: String(required): Either a base-64 encoded PGP public key, or a keybase username in the form keybase:username. Used to encrypt the password for safe transport to the user.
 
 ### Output
-* [`unique_id`]: The unique ID assigned by AWS
-* [`passwords`]: The encrypted password, base64 encoded. The encrypted password may be decrypted using: `terraform output password | base64 --decode | keybase pgp decrypt`
-* [`arns`]: The ARN assigned by AWS for this user
+* [`unique_ids`]: List of the unique IDs assigned by AWS to the users
+* [`passwords`]: List of the encrypted passwords, base64 encoded. An encrypted password may be decrypted using: `terraform output password | base64 --decode | keybase pgp decrypt`
+* [`arns`]: List of the ARNs assigned by AWS to the users
 
 ### Example
 ```

--- a/user/main.tf
+++ b/user/main.tf
@@ -9,4 +9,3 @@ resource "aws_iam_user_login_profile" "user_login" {
   pgp_key                 = var.pgp_key
   password_reset_required = "true"
 }
-

--- a/user/outputs.tf
+++ b/user/outputs.tf
@@ -1,12 +1,11 @@
-output "unique_id" {
-  value = [aws_iam_user.user.*.name]
+output "unique_ids" {
+  value = aws_iam_user.user.*.name
 }
 
 output "passwords" {
-  value = [aws_iam_user_login_profile.user_login.*.encrypted_password]
+  value = aws_iam_user_login_profile.user_login.*.encrypted_password
 }
 
 output "arns" {
-  value = [aws_iam_user.user.*.arn]
+  value = aws_iam_user.user.*.arn
 }
-


### PR DESCRIPTION
Fixes outputs for proper TF 0.12 use.

```
Error: Incorrect attribute value type

  on iam.tf line 31, in resource "aws_iam_group_membership" "foo":
  31:   users = module.users.unique_id

Inappropriate value for attribute "users": element 0: string required.
```