### PR TITLE
Allow k8s roles to access the k8s api

### DIFF
--- a/k8s_roles/k8s_roles.tf
+++ b/k8s_roles/k8s_roles.tf
@@ -71,7 +71,8 @@ data "aws_iam_policy_document" "eks_read_access" {
       "eks:DescribeUpdate",
       "eks:DescribeCluster",
       "eks:ListClusters",
-      "eks:DescribeAddonVersions"
+      "eks:DescribeAddonVersions",
+      "eks:AccessKubernetesApi"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This allows users to use the built-in k8s dashboard in the AWS console. They still need to have proper access at RBAC level.